### PR TITLE
Update rpi_pixleds.c

### DIFF
--- a/rpi_pixleds.c
+++ b/rpi_pixleds.c
@@ -70,8 +70,8 @@
 #endif
 
 // Structures for mapped I/O devices, and non-volatile memory
-extern MEM_MAP gpio_regs, dma_regs;
-MEM_MAP vc_mem, clk_regs, smi_regs;
+extern MEM_MAP gpio_regs, dma_regs, clk_regs;
+MEM_MAP vc_mem, smi_regs;
 
 // Pointers to SMI registers
 volatile SMI_CS_REG  *smi_cs;


### PR DESCRIPTION
multiple definitions of clk_regs in line 74 and rpi_dma_utils.c line 39 -> while compilation my pr 3B+ said:"gcc rpi_smi_ledpixels_jbentham/rpi_pixleds.c rpi_smi_ledpixels_jbentham/rpi_dma_utils.c
/usr/bin/ld: /tmp/ccAauXOv.o:(.bss+0x48): multiple definition of `clk_regs'; /tmp/ccVtKU7r.o:(.bss+0x18): first defined here
collect2: error: ld returned 1 exit status"